### PR TITLE
remove mention of SigLevel in archlinuxcn readme

### DIFF
--- a/content/mirror-wiki/archlinuxcn/_index.md
+++ b/content/mirror-wiki/archlinuxcn/_index.md
@@ -17,7 +17,6 @@ x86_64
 以 root 身份手动编辑文件**/etc/pacman.conf**，在文件末尾加入
 ```bash
 [archlinuxcn]
-SigLevel = TrustedOnly
 Server = https://mirrors.cqu.edu.cn/archlinuxcn/$arch
 ```
 执行：


### PR DESCRIPTION
We suggest to remove SigLevel= line and (as the official repos) use the default value in the \[options\] section.
See https://github.com/archlinuxcn/repo/blob/master/README.md